### PR TITLE
Added hot reloading capabilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ if (inBrowser) {
             var style = document.getElementById(styleId)
             if (!style) {
                 var style = document.createElement('style');
+                style.id = styleId
                 style.setAttribute('type', 'text/css');
                 document.getElementsByTagName('head')[0].appendChild(style);
             }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ if (inBrowser) {
     // register with the hotReloader wich must be present at `SystemhotReloader`
     if (typeof System.hotReloader !== "undefined") {
         console.log("hot reload: configuring hot reload for less")
-        System.hotReloader.on('change', (moduleName) => {
+        System.hotReloader.on('change', function(moduleName) {
             System.normalize(moduleName).then(function(normalizedName) {
                 var modules = importToModules[normalizedName]
                 if (modules) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ if (inBrowser) {
                     importToModules[output.imports[i]] = [load.name]
                 } else {
                     var modules = importToModules[output.imports[i]]
-                    if (modules.indexOf(load.name) !== -1) {
+                    if (modules.indexOf(load.name) === -1) {
                         modules.push(load.name)
                     }
                 }


### PR DESCRIPTION
Hi there,
I just added hot reloading capabilities to this plugin (see https://github.com/capaj/systemjs-hot-reloader).
Precondition is, that you wait for the initialization of the hot reloader and that the hot reloader is present at `System.hotReloader`.

Therefore, the bootstrapping should look like:

```
var bootstrap = Promise.resolve()
if (location.origin.match(/localhost/)) {
    System.trace = true
    bootstrap = System.import('capaj/systemjs-hot-reloader').then(function(HotReloader){
        System.hotReloader = new HotReloader.default('http://localhost:9080')  // chokidar-socket-emitter port
    })
}
bootstrap.then(function() {
    return System.import('src/app.js')
})
```
